### PR TITLE
fix(nakamoto): do not conver estimate fee

### DIFF
--- a/folgore-nakamoto/src/lib.rs
+++ b/folgore-nakamoto/src/lib.rs
@@ -211,7 +211,7 @@ impl<T: Clone> FolgoreBackend<T> for Nakamoto {
             // estimated by nakamto
             //
             // FIXME: is this a good assumtion?
-            fee_map.insert(diff, fees.high * 10_000_000);
+            fee_map.insert(diff, fees.high);
         }
         plugin.log(
             LogLevel::Debug,

--- a/folgore-plugin/src/plugin.rs
+++ b/folgore-plugin/src/plugin.rs
@@ -227,7 +227,7 @@ impl RPCCommand<PluginState> for SendRawTransactionRPC {
         plugin: &mut Plugin<PluginState>,
         request: Value,
     ) -> Result<Value, PluginError> {
-        plugin.log(LogLevel::Debug, "call get chain info");
+        plugin.log(LogLevel::Debug, "call send raw transaction");
         let mut plg = plugin.to_owned();
         let client = plg.state.client.as_mut().unwrap();
         plugin.log(LogLevel::Info, &format!("cln request: {request}"));


### PR DESCRIPTION
In bitcoin core the extimation fee is in BTC/kB, but with nakamoto we should not worried about this because the feerate should be in sats