### PR TITLE
Subject: Fix typo in readme: remote add folgore-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install it you need just to [install coffee](https://coffee-docs.netlify.app/
 run the following commands
 
 ```bash
->> coffee --network <your network> add remote folgore-git https://github.com/coffee-tools/folgore.git
+>> coffee --network <your network> remote add folgore-git https://github.com/coffee-tools/folgore.git
 >> coffee --network <your network> install folgore
 ```
 


### PR DESCRIPTION
Fixes #80 

typo in
```coffee --network <your network> add remote folgore-git https://github.com/coffee-tools/folgore.git```

changed to
```coffee --network <your network> remote add folgore-git https://github.com/coffee-tools/folgore.git```