### PR TITLE
docs: Correct plugin installation path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install it you need just to [install coffee](https://coffee-docs.netlify.app/
 run the following commands
 
 ```bash
->> coffee --network <your network> add remote folgore-git https://github.com/coffee-tools/folgore.git
+>> coffee --network <your network> remote add folgore-git https://github.com/coffee-tools/folgore.git
 >> coffee --network <your network> install folgore
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ installed](https://www.rust-lang.org/tools/install)
 
 ```
 >> make
-cp ./target/debug/folgore_plugin /home/<user>/.lightning/plugin
+cp ./target/debug/folgore_plugin /home/<user>/.lightning/plugins
 ```
 
 ### With a plugin manager


### PR DESCRIPTION
The current documentation incorrectly instructs users to copy the 
`folgore_plugin` binary to `/home/<user>/.lightning/plugin`. The correct 
path should be `/home/<user>/.lightning/plugins` for the plugin to be 
recognized properly.

This commit updates the documentation to reflect the correct path.
Fixes #91 